### PR TITLE
Cucumber Integration Tests for Controller Layer

### DIFF
--- a/config-server/src/main/resources/configs/training-report-test.yml
+++ b/config-server/src/main/resources/configs/training-report-test.yml
@@ -1,0 +1,23 @@
+server:
+  port: 9876
+
+spring:
+  sql:
+    init:
+      mode: always
+      data-locations: classpath:init/data.sql
+
+  datasource:
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password: password
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    defer-datasource-initialization: true
+    properties:
+      hibernate:
+        format_sql: true

--- a/gym-app/src/test/java/com/epam/gym/main/cucumber/runner/CucumberTests.java
+++ b/gym-app/src/test/java/com/epam/gym/main/cucumber/runner/CucumberTests.java
@@ -6,7 +6,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(
-        features = "src/test/resources/cucumber/trainer_controller.feature",
+        features = "src/test/resources/cucumber/training_controller.feature",
         glue = {"com.epam.gym.main.cucumber.stepdefinition",
                 "com.epam.gym.main.cucumber"},
         plugin = {

--- a/gym-app/src/test/java/com/epam/gym/main/cucumber/stepdefinition/TestContext.java
+++ b/gym-app/src/test/java/com/epam/gym/main/cucumber/stepdefinition/TestContext.java
@@ -1,4 +1,4 @@
-package com.epam.gym.main.cucumber.stepdefinition.trainee;
+package com.epam.gym.main.cucumber.stepdefinition;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/gym-app/src/test/java/com/epam/gym/main/cucumber/stepdefinition/trainee/CreateTraineeStepdefs.java
+++ b/gym-app/src/test/java/com/epam/gym/main/cucumber/stepdefinition/trainee/CreateTraineeStepdefs.java
@@ -1,5 +1,6 @@
 package com.epam.gym.main.cucumber.stepdefinition.trainee;
 
+import com.epam.gym.main.cucumber.stepdefinition.TestContext;
 import com.epam.gym.main.dto.TraineeRequest;
 import com.epam.gym.main.dto.UserCredentials;
 import io.cucumber.java.en.And;

--- a/gym-app/src/test/java/com/epam/gym/main/cucumber/stepdefinition/trainee/DeleteTraineeStepdefs.java
+++ b/gym-app/src/test/java/com/epam/gym/main/cucumber/stepdefinition/trainee/DeleteTraineeStepdefs.java
@@ -1,5 +1,6 @@
 package com.epam.gym.main.cucumber.stepdefinition.trainee;
 
+import com.epam.gym.main.cucumber.stepdefinition.TestContext;
 import com.epam.gym.main.dto.TraineeResponse;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;

--- a/gym-app/src/test/java/com/epam/gym/main/cucumber/stepdefinition/trainee/GetTraineeStepdefs.java
+++ b/gym-app/src/test/java/com/epam/gym/main/cucumber/stepdefinition/trainee/GetTraineeStepdefs.java
@@ -1,5 +1,6 @@
 package com.epam.gym.main.cucumber.stepdefinition.trainee;
 
+import com.epam.gym.main.cucumber.stepdefinition.TestContext;
 import com.epam.gym.main.dto.TraineeResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;

--- a/gym-app/src/test/java/com/epam/gym/main/cucumber/stepdefinition/trainee/GetTraineeTrainings.java
+++ b/gym-app/src/test/java/com/epam/gym/main/cucumber/stepdefinition/trainee/GetTraineeTrainings.java
@@ -1,5 +1,6 @@
 package com.epam.gym.main.cucumber.stepdefinition.trainee;
 
+import com.epam.gym.main.cucumber.stepdefinition.TestContext;
 import com.epam.gym.main.dto.TrainingResponse;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.When;

--- a/gym-app/src/test/java/com/epam/gym/main/cucumber/stepdefinition/trainee/UpdateTraineeStepdefs.java
+++ b/gym-app/src/test/java/com/epam/gym/main/cucumber/stepdefinition/trainee/UpdateTraineeStepdefs.java
@@ -1,5 +1,6 @@
 package com.epam.gym.main.cucumber.stepdefinition.trainee;
 
+import com.epam.gym.main.cucumber.stepdefinition.TestContext;
 import com.epam.gym.main.dto.TraineeResponse;
 import com.epam.gym.main.dto.TraineeUpdateRequest;
 import io.cucumber.java.en.And;

--- a/gym-app/src/test/java/com/epam/gym/main/cucumber/stepdefinition/trainee/UpdateTraineeTrainersStepdefs.java
+++ b/gym-app/src/test/java/com/epam/gym/main/cucumber/stepdefinition/trainee/UpdateTraineeTrainersStepdefs.java
@@ -1,5 +1,6 @@
 package com.epam.gym.main.cucumber.stepdefinition.trainee;
 
+import com.epam.gym.main.cucumber.stepdefinition.TestContext;
 import com.epam.gym.main.dto.BasicTrainerResponse;
 import com.epam.gym.main.dto.TraineeResponse;
 import io.cucumber.java.en.And;

--- a/gym-app/src/test/java/com/epam/gym/main/cucumber/stepdefinition/trainer/CreateTrainerStepdefs.java
+++ b/gym-app/src/test/java/com/epam/gym/main/cucumber/stepdefinition/trainer/CreateTrainerStepdefs.java
@@ -1,6 +1,6 @@
 package com.epam.gym.main.cucumber.stepdefinition.trainer;
 
-import com.epam.gym.main.cucumber.stepdefinition.trainee.TestContext;
+import com.epam.gym.main.cucumber.stepdefinition.TestContext;
 import com.epam.gym.main.dto.TrainerRequest;
 import com.epam.gym.main.dto.UserCredentials;
 import io.cucumber.java.en.And;

--- a/gym-app/src/test/java/com/epam/gym/main/cucumber/stepdefinition/trainer/GetTrainerStepdefs.java
+++ b/gym-app/src/test/java/com/epam/gym/main/cucumber/stepdefinition/trainer/GetTrainerStepdefs.java
@@ -1,6 +1,6 @@
 package com.epam.gym.main.cucumber.stepdefinition.trainer;
 
-import com.epam.gym.main.cucumber.stepdefinition.trainee.TestContext;
+import com.epam.gym.main.cucumber.stepdefinition.TestContext;
 import com.epam.gym.main.dto.TrainerResponse;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;

--- a/gym-app/src/test/java/com/epam/gym/main/cucumber/stepdefinition/trainer/GetTrainerTrainingsStepdefs.java
+++ b/gym-app/src/test/java/com/epam/gym/main/cucumber/stepdefinition/trainer/GetTrainerTrainingsStepdefs.java
@@ -1,6 +1,6 @@
 package com.epam.gym.main.cucumber.stepdefinition.trainer;
 
-import com.epam.gym.main.cucumber.stepdefinition.trainee.TestContext;
+import com.epam.gym.main.cucumber.stepdefinition.TestContext;
 import com.epam.gym.main.dto.TrainingResponse;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.When;

--- a/gym-app/src/test/java/com/epam/gym/main/cucumber/stepdefinition/trainer/UpdateTrainerStepdefs.java
+++ b/gym-app/src/test/java/com/epam/gym/main/cucumber/stepdefinition/trainer/UpdateTrainerStepdefs.java
@@ -1,6 +1,6 @@
 package com.epam.gym.main.cucumber.stepdefinition.trainer;
 
-import com.epam.gym.main.cucumber.stepdefinition.trainee.TestContext;
+import com.epam.gym.main.cucumber.stepdefinition.TestContext;
 import com.epam.gym.main.dto.TrainerResponse;
 import com.epam.gym.main.dto.TrainerUpdateRequest;
 import io.cucumber.java.en.And;

--- a/gym-app/src/test/java/com/epam/gym/main/cucumber/stepdefinition/training/TrainingStepdefs.java
+++ b/gym-app/src/test/java/com/epam/gym/main/cucumber/stepdefinition/training/TrainingStepdefs.java
@@ -1,0 +1,95 @@
+package com.epam.gym.main.cucumber.stepdefinition.training;
+
+import com.epam.gym.main.cucumber.stepdefinition.TestContext;
+import com.epam.gym.main.dto.TrainingRequest;
+import com.epam.gym.main.dto.TrainingTypeResponse;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.When;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@Slf4j
+@RequiredArgsConstructor
+public class TrainingStepdefs {
+
+    private final RestTemplate restTemplate;
+    private final TestContext testContext;
+    private TrainingRequest trainingRequest;
+
+    private final String baseUrl = "http://localhost:9876";
+
+    @Given("a valid training request")
+    public void aValidTrainingRequest() {
+        trainingRequest = TrainingRequest.builder()
+                .traineeUsername("Bruce.Wayne")
+                .trainerUsername("Diana.Prince")
+                .trainingName("Morning Yoga")
+                .trainingDate(LocalDateTime.parse("2025-01-15T10:00:00"))
+                .trainingDuration(90L)
+                .build();
+    }
+
+    @When("the client sends a POST request to create training at {string}")
+    public void theClientSendsAPOSTRequestToCreateTrainingAt(String url) {
+        try {
+            var response = restTemplate.postForEntity(baseUrl + url, trainingRequest, Void.class);
+            testContext.setResponse(response);
+        } catch (HttpClientErrorException e) {
+            testContext.setResponse(new ResponseEntity<>(e.getResponseBodyAsString(), e.getStatusCode()));
+        }
+    }
+
+    @And("the training is successfully created")
+    public void theTrainingIsSuccessfullyCreated() {
+        var response = testContext.getResponse();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    }
+
+    @Given("an invalid training request")
+    public void anInvalidTrainingRequest() {
+        trainingRequest = TrainingRequest.builder()
+                .traineeUsername("")
+                .trainerUsername("")
+                .trainingName("")
+                .trainingDate(LocalDateTime.parse("2020-01-01T10:00:00"))
+                .trainingDuration(-10L)
+                .build();
+    }
+
+    @Given("the system contains predefined training types")
+    public void theSystemContainsPredefinedTrainingTypes() {
+        // No explicit implementation needed here since the data is initialized in data.sql
+    }
+
+    @When("the client sends a GET request to get training types at {string}")
+    public void theClientSendsAGETRequestToGetTrainingTypesAt(String endpoint) {
+        try {
+            var url = baseUrl + endpoint;
+            var response = restTemplate.getForEntity(url, TrainingTypeResponse[].class); // Directly map to an array
+            testContext.setResponse(response);
+        } catch (HttpClientErrorException e) {
+            log.error("Error retrieving training types: Status - {}, Body - {}", e.getStatusCode(), e.getResponseBodyAsString());
+            testContext.setResponse(new ResponseEntity<>(e.getResponseBodyAsString(), e.getStatusCode()));
+        }
+    }
+
+    @And("the response contains the list of training types")
+    public void theResponseContainsTheListOfTrainingTypes() {
+        @SuppressWarnings("unchecked")
+        var response = (ResponseEntity<TrainingTypeResponse[]>) testContext.getResponse();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        var trainingTypes = response.getBody();
+        assert trainingTypes != null;
+        assertThat(trainingTypes.length).isGreaterThanOrEqualTo(5); // 5 predefined types in data.sql
+    }
+}

--- a/gym-app/src/test/resources/cucumber/training_controller.feature
+++ b/gym-app/src/test/resources/cucumber/training_controller.feature
@@ -1,0 +1,21 @@
+Feature: TrainingController API
+
+  @create-training
+  Scenario: Successfully create a new training
+    Given a valid training request
+    When the client sends a POST request to create training at "/api/v1/trainings"
+    Then the server responds with a 201 status
+    And the training is successfully created
+
+  @create-training
+  Scenario: Fail to create a training with invalid request
+    Given an invalid training request
+    When the client sends a POST request to create training at "/api/v1/trainings"
+    Then the server responds with a 400 status
+
+  @list-training-types
+  Scenario: Successfully list all training types
+    Given the system contains predefined training types
+    When the client sends a GET request to get training types at "/api/v1/trainings"
+    Then the server responds with a 200 status
+    And the response contains the list of training types

--- a/gym-app/src/test/resources/init/data.sql
+++ b/gym-app/src/test/resources/init/data.sql
@@ -1,13 +1,9 @@
 INSERT INTO training_type (id, training_type_name)
-VALUES (1, 'Yoga');
-INSERT INTO training_type (id, training_type_name)
-VALUES (2, 'Cardio');
-INSERT INTO training_type (id, training_type_name)
-VALUES (3, 'Strength Training');
-INSERT INTO training_type (id, training_type_name)
-VALUES (4, 'Pilates');
-INSERT INTO training_type (id, training_type_name)
-VALUES (5, 'HIIT');
+VALUES (1, 'CARDIO'),
+       (2, 'STRENGTH_TRAINING'),
+       (3, 'YOGA'),
+       (4, 'PILATES'),
+       (5, 'HIIT');
 ALTER SEQUENCE training_type_id_seq RESTART WITH 6;
 
 INSERT INTO users_table (id, first_name, last_name, username)

--- a/training-report/pom.xml
+++ b/training-report/pom.xml
@@ -23,6 +23,7 @@
         <cucumber.java.version>7.18.1</cucumber.java.version>
         <cucumber.junit.version>7.18.0</cucumber.junit.version>
         <cucumber.spring.version>7.18.1</cucumber.spring.version>
+        <de.flapdoodle.embed.mongo.version>4.11.1</de.flapdoodle.embed.mongo.version>
     </properties>
     <dependencies>
         <!--    ==== Spring Boot Starters ====    -->
@@ -57,6 +58,7 @@
             <version>${jackson.version}</version>
         </dependency>
 
+        <!--    ==== MongoDB ====    -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-mongodb</artifactId>
@@ -81,5 +83,14 @@
             <artifactId>cucumber-spring</artifactId>
             <version>${cucumber.spring.version}</version>
         </dependency>
+
+        <!--    ==== Embedded MongoDB ====    -->
+        <dependency>
+            <groupId>de.flapdoodle.embed</groupId>
+            <artifactId>de.flapdoodle.embed.mongo</artifactId>
+            <version>${de.flapdoodle.embed.mongo.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 </project>

--- a/training-report/src/main/java/com/epam/gym/trainingreport/TrainingReportApplication.java
+++ b/training-report/src/main/java/com/epam/gym/trainingreport/TrainingReportApplication.java
@@ -1,6 +1,7 @@
 package com.epam.gym.trainingreport;
 
 import com.epam.gym.trainingreport.dto.TrainerWorkloadRequest;
+import com.epam.gym.trainingreport.exception.CustomResponseErrorHandler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -11,6 +12,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.jms.support.converter.MappingJackson2MessageConverter;
 import org.springframework.jms.support.converter.MessageConverter;
 import org.springframework.jms.support.converter.MessageType;
+import org.springframework.web.client.RestTemplate;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -39,5 +41,12 @@ public class TrainingReportApplication {
         converter.setTypeIdMappings(typeIdMappings);
 
         return converter;
+    }
+
+    @Bean
+    public RestTemplate restTemplate() {
+        var restTemplate = new RestTemplate();
+        restTemplate.setErrorHandler(new CustomResponseErrorHandler());
+        return restTemplate;
     }
 }

--- a/training-report/src/main/java/com/epam/gym/trainingreport/controller/TrainerWorkloadController.java
+++ b/training-report/src/main/java/com/epam/gym/trainingreport/controller/TrainerWorkloadController.java
@@ -5,11 +5,13 @@ import com.epam.gym.trainingreport.dto.TrainerWorkloadRequest;
 import com.epam.gym.trainingreport.dto.TrainerWorkloadResponse;
 import com.epam.gym.trainingreport.exception.TrainerWorkloadNotFoundException;
 import com.epam.gym.trainingreport.service.TrainerWorkloadService;
+import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -18,6 +20,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor
@@ -41,7 +46,31 @@ public class TrainerWorkloadController implements TrainerWorkloadApi {
     }
 
     @ExceptionHandler(TrainerWorkloadNotFoundException.class)
-    public ResponseEntity<String> handleTrainerWorkloadNotFoundException(TrainerWorkloadNotFoundException ex) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+    public ResponseEntity<Map<String, String>> handleTrainerWorkloadNotFoundException(TrainerWorkloadNotFoundException ex) {
+        Map<String, String> errorResponse = Map.of("error", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<String> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        log.error("Validation failed: {}", ex.getMessage());
+        String errorMessage = ex.getBindingResult().getFieldErrors().stream()
+                .map(fieldError -> fieldError.getField() + ": " + fieldError.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorMessage);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException ex) {
+        log.error("Validation error: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<String> handleConstraintViolationException(ConstraintViolationException ex) {
+        String errorMessage = ex.getConstraintViolations().stream()
+                .map(violation -> violation.getPropertyPath() + ": " + violation.getMessage())
+                .collect(Collectors.joining(", "));
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorMessage);
     }
 }

--- a/training-report/src/main/java/com/epam/gym/trainingreport/exception/CustomResponseErrorHandler.java
+++ b/training-report/src/main/java/com/epam/gym/trainingreport/exception/CustomResponseErrorHandler.java
@@ -1,0 +1,17 @@
+package com.epam.gym.trainingreport.exception;
+
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.web.client.ResponseErrorHandler;
+import reactor.util.annotation.NonNull;
+
+public class CustomResponseErrorHandler implements ResponseErrorHandler {
+    @Override
+    public boolean hasError(@NonNull ClientHttpResponse response) {
+        return false;   // for preventing exception throwing on any status code
+    }
+
+    @Override
+    public void handleError(@NonNull ClientHttpResponse response) {
+        // intentionally left blank to prevent exception throwing
+    }
+}

--- a/training-report/src/main/java/com/epam/gym/trainingreport/service/TrainerWorkloadService.java
+++ b/training-report/src/main/java/com/epam/gym/trainingreport/service/TrainerWorkloadService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.Optional;
@@ -25,6 +26,14 @@ public class TrainerWorkloadService {
 
     public void createTrainerWorkload(TrainerWorkloadRequest request) {
         log.debug("Processing trainer workload with username: {}", request.getUsername());
+
+        if (request.getUsername() == null || request.getUsername().isBlank()) {
+            throw new IllegalArgumentException("Username is required");
+        }
+        if (request.getTrainingDate().isBefore(LocalDate.now())) {
+            throw new IllegalArgumentException("Training date cannot be in the past");
+        }
+
         var workload = findOrCreateTrainerWorkload(request);
 
         var year = YearMonth.from(request.getTrainingDate()).getYear();

--- a/training-report/src/main/resources/application.yml
+++ b/training-report/src/main/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  profiles:
+    active: default
+
   application:
     name: training-report
 

--- a/training-report/src/test/java/com/epam/gym/trainingreport/TrainerWorkloadDataInitializationTest.java
+++ b/training-report/src/test/java/com/epam/gym/trainingreport/TrainerWorkloadDataInitializationTest.java
@@ -1,0 +1,36 @@
+package com.epam.gym.trainingreport;
+
+import com.epam.gym.trainingreport.model.TrainerWorkload;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test") // Ensure the correct profile is used for testing
+class TrainerWorkloadDataInitializationTest {
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    @Test
+    void shouldInitializeTrainerWorkloadData() {
+        // Query the database for trainer workloads
+        List<TrainerWorkload> workloads = mongoTemplate.findAll(TrainerWorkload.class);
+
+        // Assert that the data is initialized
+        assertThat(workloads).isNotEmpty();
+        assertThat(workloads.size()).isGreaterThanOrEqualTo(1);
+
+        // Validate specific data (example)
+        TrainerWorkload workload = workloads.get(0);
+        assertThat(workload.getUsername()).isEqualTo("Peter.Parker");
+        assertThat(workload.getFirstName()).isEqualTo("Peter");
+        assertThat(workload.getLastName()).isEqualTo("Parker");
+    }
+}

--- a/training-report/src/test/java/com/epam/gym/trainingreport/cucumber/CucumberSpringConfiguration.java
+++ b/training-report/src/test/java/com/epam/gym/trainingreport/cucumber/CucumberSpringConfiguration.java
@@ -1,0 +1,12 @@
+package com.epam.gym.trainingreport.cucumber;
+
+import io.cucumber.spring.CucumberContextConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+@CucumberContextConfiguration
+@TestPropertySource(properties = "spring.profiles.active=test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@SuppressWarnings("unused")
+public class CucumberSpringConfiguration {
+}

--- a/training-report/src/test/java/com/epam/gym/trainingreport/cucumber/runner/CucumberTests.java
+++ b/training-report/src/test/java/com/epam/gym/trainingreport/cucumber/runner/CucumberTests.java
@@ -1,4 +1,4 @@
-package com.epam.gym.main.cucumber.runner;
+package com.epam.gym.trainingreport.cucumber.runner;
 
 import io.cucumber.junit.Cucumber;
 import io.cucumber.junit.CucumberOptions;
@@ -7,8 +7,7 @@ import org.junit.runner.RunWith;
 @RunWith(Cucumber.class)
 @CucumberOptions(
         features = "src/test/resources/cucumber",
-        glue = {"com.epam.gym.main.cucumber.stepdefinition",
-                "com.epam.gym.main.cucumber"},
+        glue = "com.epam.gym.trainingreport.cucumber",
         plugin = {
                 "pretty",
                 "html:target/cucumber-reports.html",

--- a/training-report/src/test/java/com/epam/gym/trainingreport/cucumber/stepdefs/TrainerWorkloadStepdefs.java
+++ b/training-report/src/test/java/com/epam/gym/trainingreport/cucumber/stepdefs/TrainerWorkloadStepdefs.java
@@ -1,0 +1,143 @@
+package com.epam.gym.trainingreport.cucumber.stepdefs;
+
+import com.epam.gym.trainingreport.dto.TrainerWorkloadRequest;
+import com.epam.gym.trainingreport.dto.TrainerWorkloadResponse;
+import com.epam.gym.trainingreport.model.ActionType;
+import com.epam.gym.trainingreport.model.TrainerWorkload;
+import com.epam.gym.trainingreport.model.TrainingDuration;
+import com.epam.gym.trainingreport.model.TrainingYear;
+import com.epam.gym.trainingreport.repository.TrainerWorkloadRepository;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Before;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@RequiredArgsConstructor
+public class TrainerWorkloadStepdefs {
+
+    private final RestTemplate restTemplate;
+    private final TrainerWorkloadRepository trainerWorkloadRepository;
+
+    private TrainerWorkloadRequest workloadRequest;
+    private ResponseEntity<?> response;
+    private final String baseUrl = "http://localhost:9876/api/v1/workload";
+
+    @Before
+    public void setup() {
+        trainerWorkloadRepository.deleteAll();
+
+        TrainerWorkload workload = TrainerWorkload.builder()
+                .id("1")
+                .username("Peter.Parker")
+                .firstName("Peter")
+                .lastName("Parker")
+                .isActive(true)
+                .yearlySummary(List.of(
+                        TrainingYear.builder()
+                                .year(2023)
+                                .trainingDurations(List.of(
+                                        TrainingDuration.builder()
+                                                .month(1)
+                                                .totalDuration(120)
+                                                .build(),
+                                        TrainingDuration.builder()
+                                                .month(2)
+                                                .totalDuration(100)
+                                                .build()
+                                ))
+                                .build()
+                ))
+                .build();
+
+        trainerWorkloadRepository.save(workload);
+        log.info("Data initialization of TrainerWorkload collection is completed");
+    }
+
+    @Given("a valid trainer workload request")
+    public void aValidTrainerWorkloadRequest() {
+        workloadRequest = TrainerWorkloadRequest.builder()
+                .username("Peter.Parker")
+                .firstName("Peter")
+                .lastName("Parker")
+                .isActive(true)
+                .trainingDate(LocalDate.now())
+                .trainingDuration(120)
+                .actionType(ActionType.ADD)
+                .build();
+    }
+
+    @Given("an invalid trainer workload request")
+    public void anInvalidTrainerWorkloadRequest() {
+        workloadRequest = TrainerWorkloadRequest.builder()
+                .username("")
+                .firstName("")
+                .lastName("")
+                .isActive(null)
+                .trainingDate(LocalDate.now().minusDays(1))
+                .trainingDuration(-10)
+                .actionType(null)
+                .build();
+    }
+
+    @When("the client sends a POST request to {string}")
+    public void theClientSendsAPOSTRequestTo(String endpoint) {
+        try {
+            response = restTemplate.postForEntity(baseUrl + endpoint, workloadRequest, Void.class);
+        } catch (HttpClientErrorException e) {
+            response = new ResponseEntity<>(e.getResponseBodyAsString(), e.getStatusCode());
+        }
+    }
+
+    @Then("the server responds with a {int} status")
+    public void theServerRespondsWithAStatus(int expectedStatus) {
+        assertThat(response.getStatusCode().value()).isEqualTo(expectedStatus);
+    }
+
+    @And("the trainer workload is successfully created")
+    public void theTrainerWorkloadIsSuccessfullyCreated() {
+        Optional<TrainerWorkload> workload = trainerWorkloadRepository.findByUsername("Peter.Parker");
+        assertThat(workload).isPresent();
+        assertThat(workload.get().getFirstName()).isEqualTo("Peter");
+        assertThat(workload.get().getYearlySummary()).isNotEmpty();
+    }
+
+    @Given("an existing trainer username {string}")
+    public void anExistingTrainerUsername(String username) {
+        assertThat(trainerWorkloadRepository.findByUsername(username)).isPresent();
+    }
+
+    @When("the client sends a GET request to {string}")
+    public void theClientSendsAGETRequestTo(String endpoint) {
+        try {
+            response = restTemplate.getForEntity(baseUrl + endpoint, TrainerWorkloadResponse.class);
+        } catch (HttpClientErrorException e) {
+            response = new ResponseEntity<>(e.getResponseBodyAsString(), e.getStatusCode());
+        }
+    }
+
+    @And("the response contains the trainer's workload summary")
+    public void theResponseContainsTheTrainerSWorkloadSummary() {
+        TrainerWorkloadResponse workloadResponse = (TrainerWorkloadResponse) response.getBody();
+        assertThat(workloadResponse).isNotNull();
+        assertThat(workloadResponse.username()).isEqualTo("Peter.Parker");
+        assertThat(workloadResponse.yearlySummary()).isNotEmpty();
+    }
+
+    @Given("a non-existing trainer username {string}")
+    public void aNonExistingTrainerUsername(String username) {
+        assertThat(trainerWorkloadRepository.findByUsername(username)).isNotPresent();
+    }
+}

--- a/training-report/src/test/resources/cucumber/trainer_workload_controller.feature
+++ b/training-report/src/test/resources/cucumber/trainer_workload_controller.feature
@@ -1,0 +1,27 @@
+Feature: TrainerWorkloadController API
+
+  @create-trainer-workload
+  Scenario: Successfully create trainer workload
+    Given a valid trainer workload request
+    When the client sends a POST request to "/report"
+    Then the server responds with a 201 status
+    And the trainer workload is successfully created
+
+  @create-trainer-workload
+  Scenario: Fail to create trainer workload with invalid request
+    Given an invalid trainer workload request
+    When the client sends a POST request to "/report"
+    Then the server responds with a 400 status
+
+  @get-trainer-workload
+  Scenario: Successfully get trainer workload summary
+    Given an existing trainer username "Peter.Parker"
+    When the client sends a GET request to "/Peter.Parker"
+    Then the server responds with a 200 status
+    And the response contains the trainer's workload summary
+
+  @get-trainer-workload
+  Scenario: Fail to get workload for a non-existing trainer
+    Given a non-existing trainer username "No.Trainer"
+    When the client sends a GET request to "/No.Trainer"
+    Then the server responds with a 404 status


### PR DESCRIPTION
This PR adds integration tests using Cucumber for the controller layer of the following services: Auth-Service, Training-Report, and Gym-App.

- Written feature files, step definitions, and runners for testing API endpoints.
- Focused on controller logic as there's no UI layer yet.

Note: Two commits: "add cucumber test for trainer_workload" and "add cucumber test for training_controller" **are not included in this PR** due to a missed merge. You can view these changes in the commit history of the "develop" branch.